### PR TITLE
Added new workflows

### DIFF
--- a/workflows/Galaxy-Workflow-Registration_of_images_based_on_intensity_information.ga
+++ b/workflows/Galaxy-Workflow-Registration_of_images_based_on_intensity_information.ga
@@ -1,0 +1,318 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Registration of images based on intensity information",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Moving image"
+                }
+            ],
+            "label": "Moving image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 193,
+                "height": 81,
+                "left": 402,
+                "right": 602,
+                "top": 112,
+                "width": 200,
+                "x": 402,
+                "y": 112
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "78e303e9-1c42-4476-b3b6-0190c47166ce",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "a820011b-4d91-485c-8248-3157e7890c3a"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Reference (fixed) image"
+                }
+            ],
+            "label": "Reference (fixed) image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 744,
+                "height": 81,
+                "left": 413,
+                "right": 613,
+                "top": 663,
+                "width": 200,
+                "x": 413,
+                "y": 663
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "8dea8197-01dd-4781-9f34-75b01914a134",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "0445e743-fed7-40c6-8529-78f04a1d40d3"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_smooth/imagej2_smooth/3.0.0",
+            "errors": null,
+            "id": 2,
+            "input_connections": {
+                "input": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Smooth",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Smooth",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 364,
+                "height": 92,
+                "left": 542,
+                "right": 742,
+                "top": 272,
+                "width": 200,
+                "x": 542,
+                "y": 272
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_smooth/imagej2_smooth/3.0.0",
+            "tool_shed_repository": {
+                "changeset_revision": "53fb6f4afcc8",
+                "name": "imagej2_smooth",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "6be808fb-de4f-4b67-9fcc-d8f01b32e9e5",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "3d5dc41f-9cee-4445-b3db-f8cc62bd2f39"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_smooth/imagej2_smooth/3.0.0",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "input": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Smooth",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Smooth",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "bottom": 574,
+                "height": 92,
+                "left": 543,
+                "right": 743,
+                "top": 482,
+                "width": 200,
+                "x": 543,
+                "y": 482
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/imagej2_smooth/imagej2_smooth/3.0.0",
+            "tool_shed_repository": {
+                "changeset_revision": "53fb6f4afcc8",
+                "name": "imagej2_smooth",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "48f75a05-cf7a-48d1-b22b-d4cf56cbb71a",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "2a3b502b-a83f-463c-819f-78c3e8818b32"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/image_registration_affine/ip_image_registration/0.0.1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "fn_fixed": {
+                    "id": 3,
+                    "output_name": "output"
+                },
+                "fn_moving": {
+                    "id": 2,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Image Registration",
+                    "name": "fn_fixed"
+                },
+                {
+                    "description": "runtime parameter for tool Image Registration",
+                    "name": "fn_moving"
+                }
+            ],
+            "label": null,
+            "name": "Image Registration",
+            "outputs": [
+                {
+                    "name": "fn_tmat",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 513,
+                "height": 142,
+                "left": 802,
+                "right": 1002,
+                "top": 371,
+                "width": 200,
+                "x": 802,
+                "y": 371
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/image_registration_affine/ip_image_registration/0.0.1",
+            "tool_shed_repository": {
+                "changeset_revision": "e34222a620d4",
+                "name": "image_registration_affine",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"fn_fixed\": {\"__class__\": \"RuntimeValue\"}, \"fn_moving\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "75a8ac98-b71c-45bf-b379-d5c9f86b44c2",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "fn_tmat",
+                    "uuid": "659c1d70-de0d-4ed1-822e-025260ef5cbf"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.0.4",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "fixed_image": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "moving_image": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "warp_matrix": {
+                    "id": 4,
+                    "output_name": "fn_tmat"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Projective Transformation",
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "bottom": 546,
+                "height": 172,
+                "left": 1237,
+                "right": 1437,
+                "top": 374,
+                "width": 200,
+                "x": 1237,
+                "y": 374
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.0.4",
+            "tool_shed_repository": {
+                "changeset_revision": "974cf4357707",
+                "name": "projective_transformation",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"fixed_image\": {\"__class__\": \"ConnectedValue\"}, \"moving_image\": {\"__class__\": \"ConnectedValue\"}, \"warp_matrix\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "b90cbf09-3b69-4a5a-977b-1c974e3ae08b",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out",
+                    "uuid": "2d61abeb-e67c-45ca-b081-5c185ebcaa1b"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "fd0e528d-8532-4db8-b5c0-7a76e8e4d03f",
+    "version": 4
+}

--- a/workflows/Galaxy-Workflow-Registration_of_images_based_on_landmarks_using_RANSAC.ga
+++ b/workflows/Galaxy-Workflow-Registration_of_images_based_on_landmarks_using_RANSAC.ga
@@ -1,0 +1,275 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Registration of images based on landmarks using RANSAC",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Moving image"
+                }
+            ],
+            "label": "Moving image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 311,
+                "height": 81,
+                "left": 514.5,
+                "right": 714.5,
+                "top": 230,
+                "width": 200,
+                "x": 514.5,
+                "y": 230
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "c918c60c-2e2c-4f17-b40c-ed07bd721e96",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "bb0f65d2-72a8-4cb6-acce-8b4642edced4"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Reference (fixed) image"
+                }
+            ],
+            "label": "Reference (fixed) image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 438.171875,
+                "height": 81,
+                "left": 520.40625,
+                "right": 720.40625,
+                "top": 357.171875,
+                "width": 200,
+                "x": 520.40625,
+                "y": 357.171875
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "4e7c0c11-6308-433b-bfca-71a159dd9e93",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "689cf052-d5fc-4cdb-bc19-8934f873e2ed"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "landmarks in reference image"
+                }
+            ],
+            "label": "landmarks in reference image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 560.359375,
+                "height": 81,
+                "left": 520.90625,
+                "right": 720.90625,
+                "top": 479.359375,
+                "width": 200,
+                "x": 520.90625,
+                "y": 479.359375
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "129cfd42-5851-4416-85ef-5dd9d9541df8",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "341a9978-6809-4ba0-9940-97204fced795"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 3,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Landmarks in moving image "
+                }
+            ],
+            "label": "Landmarks in moving image ",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 668.546875,
+                "height": 81,
+                "left": 520.59375,
+                "right": 720.59375,
+                "top": 587.546875,
+                "width": 200,
+                "x": 520.59375,
+                "y": 587.546875
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "d123446f-16bb-47c6-90cc-4959a9ff1e7a",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "0f93a89e-a00a-4a6d-9fd9-2eb0f192a78c"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration/ip_landmark_registration/0.0.2",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "points_file1": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "points_file2": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Landmark Registration",
+            "outputs": [
+                {
+                    "name": "warp_matrix",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 624.28125,
+                "height": 182,
+                "left": 831.78125,
+                "right": 1031.78125,
+                "top": 442.28125,
+                "width": 200,
+                "x": 831.78125,
+                "y": 442.28125
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration/ip_landmark_registration/0.0.2",
+            "tool_shed_repository": {
+                "changeset_revision": "b0503eec7bd6",
+                "name": "landmark_registration",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"max_trials\": \"100\", \"points_file1\": {\"__class__\": \"ConnectedValue\"}, \"points_file2\": {\"__class__\": \"ConnectedValue\"}, \"residual_threshold\": \"2.0\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "09253135-540f-4ec4-91d9-1f7a8b9502da",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "warp_matrix",
+                    "uuid": "b565e6c4-38e6-463d-8262-64b09172d3fc"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.0.4",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "fixed_image": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "moving_image": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "warp_matrix": {
+                    "id": 4,
+                    "output_name": "warp_matrix"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Projective Transformation",
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "bottom": 419.546875,
+                "height": 172,
+                "left": 1120.03125,
+                "right": 1320.03125,
+                "top": 247.546875,
+                "width": 200,
+                "x": 1120.03125,
+                "y": 247.546875
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.0.4",
+            "tool_shed_repository": {
+                "changeset_revision": "974cf4357707",
+                "name": "projective_transformation",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"fixed_image\": {\"__class__\": \"ConnectedValue\"}, \"moving_image\": {\"__class__\": \"ConnectedValue\"}, \"warp_matrix\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "3b3f7f81-d4f9-49cd-b1b3-91ead30b0663",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out",
+                    "uuid": "da630452-dcea-47db-b7fb-c1b2d9549f54"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "1b851797-d9c0-43e3-bca3-c5f1652fc7b1",
+    "version": 7
+}

--- a/workflows/Galaxy-Workflow-Registration_of_images_based_on_landmarks_using_least_squares.ga
+++ b/workflows/Galaxy-Workflow-Registration_of_images_based_on_landmarks_using_least_squares.ga
@@ -1,0 +1,284 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "",
+    "format-version": "0.1",
+    "name": "Registration of images based on landmarks using least squares",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Moving image"
+                }
+            ],
+            "label": "Moving image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 366,
+                "height": 81,
+                "left": 717,
+                "right": 917,
+                "top": 285,
+                "width": 200,
+                "x": 717,
+                "y": 285
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "8d3b544c-bc16-49a8-a945-da579eef17e3",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "f3d7a78c-880a-4cf1-8c60-c3818b78b398"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Reference (fixed) image"
+                }
+            ],
+            "label": "Reference (fixed) image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 493.171875,
+                "height": 81,
+                "left": 722.90625,
+                "right": 922.90625,
+                "top": 412.171875,
+                "width": 200,
+                "x": 722.90625,
+                "y": 412.171875
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "e9cd5cdc-a682-4a0c-a3f6-ba9f58632ccb",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "abcc3858-b58a-4859-9231-754cf17b4fab"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 2,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "landmarks in reference image"
+                }
+            ],
+            "label": "landmarks in reference image",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 615.359375,
+                "height": 81,
+                "left": 723.40625,
+                "right": 923.40625,
+                "top": 534.359375,
+                "width": 200,
+                "x": 723.40625,
+                "y": 534.359375
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "6786e622-e470-450d-b1ee-86e319e9e2fe",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "b77cedc5-8f05-4d00-8fcf-4250193ee317"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 3,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "Landmarks in moving image "
+                }
+            ],
+            "label": "Landmarks in moving image ",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "bottom": 723.546875,
+                "height": 81,
+                "left": 723.09375,
+                "right": 923.09375,
+                "top": 642.546875,
+                "width": 200,
+                "x": 723.09375,
+                "y": 642.546875
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "33ab9953-a55a-40ee-b064-b03eac26db5f",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "6fd8d9cd-bd9e-45c2-84a1-8f3f908891cc"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration_ls/ip_landmark_registration_ls/0.0.1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "fn_pts1": {
+                    "id": 2,
+                    "output_name": "output"
+                },
+                "fn_pts2": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Landmark Registration",
+                    "name": "fn_pts1"
+                },
+                {
+                    "description": "runtime parameter for tool Landmark Registration",
+                    "name": "fn_pts2"
+                }
+            ],
+            "label": null,
+            "name": "Landmark Registration",
+            "outputs": [
+                {
+                    "name": "fn_tmat",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "bottom": 695.5,
+                "height": 182,
+                "left": 1018,
+                "right": 1218,
+                "top": 513.5,
+                "width": 200,
+                "x": 1018,
+                "y": 513.5
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/landmark_registration_ls/ip_landmark_registration_ls/0.0.1",
+            "tool_shed_repository": {
+                "changeset_revision": "2f36165c49fb",
+                "name": "landmark_registration_ls",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"fn_pts1\": {\"__class__\": \"RuntimeValue\"}, \"fn_pts2\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "3a47361d-6fed-4c82-9933-308e4ebcb691",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "fn_tmat",
+                    "uuid": "fc8e7cd2-10bc-4bf6-94ef-a518acb9d5ac"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.0.4",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "fixed_image": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "moving_image": {
+                    "id": 0,
+                    "output_name": "output"
+                },
+                "warp_matrix": {
+                    "id": 4,
+                    "output_name": "fn_tmat"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Projective Transformation",
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "png"
+                }
+            ],
+            "position": {
+                "bottom": 474.546875,
+                "height": 172,
+                "left": 1322.53125,
+                "right": 1522.53125,
+                "top": 302.546875,
+                "width": 200,
+                "x": 1322.53125,
+                "y": 302.546875
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/imgteam/projective_transformation/ip_projective_transformation/0.0.4",
+            "tool_shed_repository": {
+                "changeset_revision": "974cf4357707",
+                "name": "projective_transformation",
+                "owner": "imgteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"fixed_image\": {\"__class__\": \"ConnectedValue\"}, \"moving_image\": {\"__class__\": \"ConnectedValue\"}, \"warp_matrix\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": null,
+            "type": "tool",
+            "uuid": "dd04a6cf-209c-414b-9fed-044295088e24",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out",
+                    "uuid": "630b7bbe-3ce8-4a83-8d50-df73524e2417"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "09f5751b-7dff-455d-9a86-6c02bc14a329",
+    "version": 4
+}


### PR DESCRIPTION
The difference between workflows "Registration of images based on landmarks using RANSAC" and "Registration of images based on landmarks using least squares" is that different tools are chosen for computing the transformation matrix. Is it possible that these two workflows are merged into a single one and the users decide which tool (RANSAC or least squares) to use when running the workflow? 