### PR TITLE
applies CI changes from IUC missed in #78

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ on:
       - '*'
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_23.0
+  GALAXY_BRANCH: release_23.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:
@@ -309,6 +309,8 @@ jobs:
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v1
       id: cpu-cores
+    - name: Clean dotnet folder for space
+      run: rm -Rf /usr/share/dotnet
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test


### PR DESCRIPTION
Deployment still fails after #78: https://github.com/BMCV/galaxy-image-analysis/actions/runs/6810454241/job/18519017525

The only differences left between the pr.yaml of [this repo](https://github.com/BMCV/galaxy-image-analysis/blob/master/.github/workflows/pr.yaml) and [the IUC version](https://github.com/galaxyproject/tools-iuc/blob/main/.github/workflows/pr.yaml), aside from repository names, are:

1. `GALAXY_BRANCH: release_23.0`, which is `release_23.1` in IUC.
2. There is a section
```yaml
    - name: Clean dotnet folder for space
      run: rm -Rf /usr/share/dotnet
```
added to the steps section in line 312.

Both changes are applied in this PR.

xref https://github.com/BMCV/galaxy-image-analysis/pull/71#issuecomment-1803581183

---

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the galaxy-image-analysis repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
* [x] - Tools added/updated by this PR (if any) comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://github.com/elixir-europe/biohackathon-projects-2023/blob/main/16/conventions.md) (or please explain why they do not)
