### PR TITLE
trigger ci, deploy missing tools

### DIFF
--- a/tools/2d_simple_filter/.shed.yml
+++ b/tools/2d_simple_filter/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: 2d simple filter
 long_description: Simple filter in 2D
-name: 2d_simple_filter 
+name: 2d_simple_filter  
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/2d_simple_filter/


### PR DESCRIPTION
trigger ci after #81 to deploy the tools which haven't been deployed from #76 

xref #71 

---

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the galaxy-image-analysis repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
* [ ] - Tools added/updated by this PR (if any) comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://github.com/elixir-europe/biohackathon-projects-2023/blob/main/16/conventions.md) (or please explain why they do not)
