### PR TITLE
potential fix for CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -125,24 +125,17 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-    - name: Set fail level for pull request
-      if: ${{ github.event_name == 'pull_request' }}
-      run:
-        echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
-    - name: Set fail level for merge
-      if: ${{ github.event_name != 'pull_request' }}
-      run:
-        echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
     - name: Planemo lint
+      if: ${{ github.event_name == 'pull_request' }}
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
       with:
         mode: lint
-        fail-level: ${{ env.FAIL_LEVEL }}
+        fail-level: 'error'
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
     - uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
+      if: ${{ github.event_name == 'pull_request' && failure() }}
       with:
         name: 'Tool linting output'
         path: lint_report.txt

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -128,11 +128,11 @@ jobs:
     - name: Set fail level for pull request
       if: ${{ github.event_name == 'pull_request' }}
       run:
-        echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
+        echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
     - name: Set fail level for merge
       if: ${{ github.event_name != 'pull_request' }}
       run:
-        echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
+        echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,7 +131,7 @@ jobs:
       id: lint
       with:
         mode: lint
-        fail-level: 'error'
+        fail-level: 'warn'
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -128,11 +128,11 @@ jobs:
     - name: Set fail level for pull request
       if: ${{ github.event_name == 'pull_request' }}
       run:
-        echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
+        echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
     - name: Set fail level for merge
       if: ${{ github.event_name != 'pull_request' }}
       run:
-        echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
+        echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint


### PR DESCRIPTION
The requirement is that the CI deploys tools even if planemo lint raises an error during merge.

The current configuration of the CI sets`--fail_level` passed to `planemo shed_lint` to `error`:
https://github.com/BMCV/galaxy-image-analysis/actions/runs/6811812716/job/18523060276#step:7:355
To my understanding, this makes the linter fail only if it produces an error (but not if it produces warnings).
https://help.galaxyproject.org/t/make-a-repository-installable/8156/6

What we want instead, is, that the linter never fails during merge, not even if an error is encountered! However, only the options `warn` and `error` are allowed:
```
$ planemo shed_lint --help |grep fail_level
  --fail_level [warn|error]
```

Thus, the required behavior is out of scope of `fail_level`. It can only be achieved by skipping linting during merge. This should be implemented by this PR (hopefully, never digged myself into GitHub actions before).

xref #82 #71 

---

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the galaxy-image-analysis repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [x] - This PR does something else (explain below)
* [ ] - Tools added/updated by this PR (if any) comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://github.com/elixir-europe/biohackathon-projects-2023/blob/main/16/conventions.md) (or please explain why they do not)
