### PR TITLE
temporarily skip xsd linting during deployment

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,7 @@ on:
       - '*'
 env:
   GALAXY_FORK: galaxyproject
+  # TODO remove additional-planemo-options from lint once biii is allowed in xsd
   GALAXY_BRANCH: release_23.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
@@ -127,12 +128,14 @@ jobs:
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Set fail level for pull request
       if: ${{ github.event_name == 'pull_request' }}
-      run:
+      run: |
         echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
+        echo "SKIP=-s tool_xsd" >> "$GITHUB_ENV"
     - name: Set fail level for merge
       if: ${{ github.event_name != 'pull_request' }}
       run:
         echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
+        echo "SKIP=-s tool_xsd" >> "$GITHUB_ENV"
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -141,6 +144,7 @@ jobs:
         fail-level: ${{ env.FAIL_LEVEL }}
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
+        additional-planemo-options: ${{ env.SKIP }}
     - uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:


### PR DESCRIPTION
Guess this might be a "solution", i.e. only the xsd linter is skipped during deployment. Still reviewers of PR should check the linter output manually as long as this is active. Not sure if this is worth the effort or if its better to add the xiii xref after it has support in Galaxy. Maybe we should also relax the linter here or allow some free text references using an additional tag? What do you think @bgruening 

Not sure if the space in `-s tool_xsd` needs some quoting. Maybe we can just try.



FOR CONTRIBUTOR:
* [ ] - I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the galaxy-image-analysis repo.
* [ ] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [ ] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
* [ ] - Tools added/updated by this PR (if any) comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://github.com/elixir-europe/biohackathon-projects-2023/blob/main/16/conventions.md) (or please explain why they do not)
