### PR TITLE
trigger ci, deploy missing tools

### DIFF
--- a/tools/2d_simple_filter/.shed.yml
+++ b/tools/2d_simple_filter/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: 2d simple filter
 long_description: Simple filter in 2D
-name: 2d_simple_filter   
+name: 2d_simple_filter    
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/2d_simple_filter/


### PR DESCRIPTION
trigger ci after b0de24c to deploy the tools which haven't been deployed from #76

xref #71 #84
