### PR TITLE
trigger ci, deploy missing tools

### DIFF
--- a/tools/2d_filter_segmentation_by_features/.shed.yml
+++ b/tools/2d_filter_segmentation_by_features/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: filter segmentation by rules
 long_description: Filter segmentation by features
-name: 2d_filter_segmentation_by_features
+name: 2d_filter_segmentation_by_features 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/2d_filter_segmentation_by_features/

--- a/tools/2d_histogram_equalization/.shed.yml
+++ b/tools/2d_histogram_equalization/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: 2d histogram equalization
 long_description: Automatic histogram equalization in 2D
-name: 2d_histogram_equalization
+name: 2d_histogram_equalization 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/2d_histogram_equalization/

--- a/tools/anisotropic_diffusion/.shed.yml
+++ b/tools/anisotropic_diffusion/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Anisotropic image diffusion
 long_description: Edge-preserving, Anisotropic image diffusion.
-name: anisotropic_diffusion
+name: anisotropic_diffusion 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/anisotropic-diffusion/

--- a/tools/binary2labelimage/.shed.yml
+++ b/tools/binary2labelimage/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Binary 2 label image
 long_description: This tools converts a binary image to a label image (every object has an own grey value).
-name: binary2labelimage
+name: binary2labelimage 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/binary2labelimage/

--- a/tools/binaryimage2points/.shed.yml
+++ b/tools/binaryimage2points/.shed.yml
@@ -3,7 +3,7 @@ categories:
   - Imaging
 description: Binary Image to Points
 long_description: This tool calculates the center of mass of a binary image.
-name: binaryimage2points
+name: binaryimage2points 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/binaryimage2points/

--- a/tools/color-deconvolution/.shed.yml
+++ b/tools/color-deconvolution/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Color-deconvolution methods
 long_description: This tools does color space transformation using preset transformation matrices or color space decomposition.
-name: color_deconvolution
+name: color_deconvolution 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/color-deconvolution/

--- a/tools/concat_channels/.shed.yml
+++ b/tools/concat_channels/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Concatenate images
 long_description: This tool concatenates images.
-name: concat_channels
+name: concat_channels 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/concat_channels/

--- a/tools/coordinates_of_roi/.shed.yml
+++ b/tools/coordinates_of_roi/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Coordinates of ROI
 long_description: Obtains the coordinates regions of interest on an image
-name: coordinates_of_roi
+name: coordinates_of_roi 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/coordinates_of_roi/

--- a/tools/count_objects/.shed.yml
+++ b/tools/count_objects/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Count Objects
 long_description: Count objects in an image
-name: count_objects
+name: count_objects 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/count_objects/

--- a/tools/curve_fitting/.shed.yml
+++ b/tools/curve_fitting/.shed.yml
@@ -1,4 +1,4 @@
-name: curve_fitting
+name: curve_fitting 
 owner: imgteam
 categories:
   - Imaging

--- a/tools/detection_viz/.shed.yml
+++ b/tools/detection_viz/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Detection Visualization
 long_description: This tool visualizes detection.
-name: detection_viz
+name: detection_viz 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/detection_viz/

--- a/tools/image_registration_affine/.shed.yml
+++ b/tools/image_registration_affine/.shed.yml
@@ -1,4 +1,4 @@
-name: image_registration_affine
+name: image_registration_affine 
 owner: imgteam
 categories:
   - Imaging

--- a/tools/imagecoordinates_flipaxis/.shed.yml
+++ b/tools/imagecoordinates_flipaxis/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Flip coordinate axes
 long_description: Makes x the horizontal axis (left to right) and y the vertical axis (bottom to top), like in a coordinate system
-name: imagecoordinates_flipaxis
+name: imagecoordinates_flipaxis 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/imagecoordinates_flipaxis/

--- a/tools/labelimage2points/.shed.yml
+++ b/tools/labelimage2points/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Label Image to Points
 long_description: This tool converts a label image to points.
-name: labelimage2points
+name: labelimage2points 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/labelimage2points/

--- a/tools/landmark_registration/.shed.yml
+++ b/tools/landmark_registration/.shed.yml
@@ -3,7 +3,7 @@ categories:
 description: Landmark Registration
 long_description: |
   1) Estimation of the affine transformation matrix between two sets of 2d points; 2) Piecewise affine transformation of points based on landmark pairs.
-name: landmark_registration
+name: landmark_registration 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/landmark_registration/

--- a/tools/mergeneighboursinlabelimage/.shed.yml
+++ b/tools/mergeneighboursinlabelimage/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Merge Neighbours in Label Image
 long_description: This tools merges nearby objects in a label image using the minimum pixel distance.
-name: mergeneighboursinlabelimage
+name: mergeneighboursinlabelimage 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/\mergeneighboursinlabelimage

--- a/tools/overlay_images/.shed.yml
+++ b/tools/overlay_images/.shed.yml
@@ -1,4 +1,4 @@
-name: overlay_images
+name: overlay_images 
 owner: imgteam
 categories:
   - Imaging

--- a/tools/permutate_axis/.shed.yml
+++ b/tools/permutate_axis/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Permutates axes
 long_description: Edge-preserving, Anisotropic image diffusion.
-name: permutate_axis
+name: permutate_axis 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/permutate_axis/

--- a/tools/points2binaryimage/.shed.yml
+++ b/tools/points2binaryimage/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Points to Binary Image
 long_description: Converts points to binary image.
-name: points2binaryimage
+name: points2binaryimage 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/points2binaryimage/

--- a/tools/points2labelimage/.shed.yml
+++ b/tools/points2labelimage/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Points to label image
 long_description: Converts points to label image
-name: points2labelimage
+name: points2labelimage 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/points2labelimage/

--- a/tools/points_association_nn/.shed.yml
+++ b/tools/points_association_nn/.shed.yml
@@ -1,4 +1,4 @@
-name: points_association_nn
+name: points_association_nn 
 owner: imgteam
 categories:
   - Imaging

--- a/tools/projective_transformation/.shed.yml
+++ b/tools/projective_transformation/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Projective transformation
 long_description: This tool performs a projective transformation of the input (moving) image so that it fits the fixed image. Returns the projected image.
-name: projective_transformation
+name: projective_transformation 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/projective_transformation/

--- a/tools/projective_transformation_points/.shed.yml
+++ b/tools/projective_transformation_points/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Projective transformation of ROIs defined by pixel (point) coordinates
 long_description: This tool performs a projective transformation of regions of interest (ROIs) defined by pixel (point) coordinates based on a given transformation matrix.
-name: projective_transformation_points
+name: projective_transformation_points 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/projective_transformation_points/

--- a/tools/segmetrics/.shed.yml
+++ b/tools/segmetrics/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Image segmentation and object detection performance measures
 long_description: Image segmentation and object detection performance measures for 2-D image data.
-name: segmetrics
+name: segmetrics 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/segmetrics/

--- a/tools/slice_image/.shed.yml
+++ b/tools/slice_image/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Slice image
 long_description: Slices original image into several smaller patches
-name: slice_image
+name: slice_image 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/slice_image/

--- a/tools/split_labelmap/.shed.yml
+++ b/tools/split_labelmap/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Split Labelmaps
 long_description: Separates different labels in the same image by creating a new image
-name: split_labelmap
+name: split_labelmap 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/split_labelmaps/

--- a/tools/spot_detection_2d/.shed.yml
+++ b/tools/spot_detection_2d/.shed.yml
@@ -1,4 +1,4 @@
-name: spot_detection_2d
+name: spot_detection_2d 
 owner: imgteam
 categories:
   - Imaging

--- a/tools/superdsm/.shed.yml
+++ b/tools/superdsm/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Globally optimal segmentation method based on superadditivity and deformable shape models for cell nuclei in fluorescence microscopy images
 long_description: Globally optimal segmentation method based on superadditivity and deformable shape models for cell nuclei in 2-D fluorescence microscopy images.
-name: superdsm
+name: superdsm 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/superdsm/

--- a/tools/wsi_extract_top_view/.shed.yml
+++ b/tools/wsi_extract_top_view/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: WSI Extract Top View
 long_description: Extracts the top view of a whole-slide image (=virtual slide).
-name: wsi_extract_top_view
+name: wsi_extract_top_view 
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/wsi_extract_top_view/


### PR DESCRIPTION
trigger ci after https://github.com/BMCV/galaxy-image-analysis/commit/b0de24c7943dffb01719618741060f3d9359eee5 to deploy the tools which haven't been deployed from https://github.com/BMCV/galaxy-image-analysis/pull/71 and #87 (still managed to miss some 🤯)

xref https://github.com/BMCV/galaxy-image-analysis/pull/84