### PR TITLE
Rename tools

### DIFF
--- a/tools/projective_transformation/projective_transformation.xml
+++ b/tools/projective_transformation/projective_transformation.xml
@@ -1,5 +1,9 @@
-<tool id="ip_projective_transformation" name="Perform projective transformation with/without labels" version="0.1.2-2" profile="20.05"> 
+<tool id="ip_projective_transformation" name="Perform projective transformation with/without labels" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.05"> 
     <description></description>
+    <macros>
+        <token name="@TOOL_VERSION@">0.1.2</token>
+        <token name="@VERSION_SUFFIX@">3</token>
+    </macros>
     <edam_operations>
         <edam_operation>operation_3443</edam_operation>
     </edam_operations>

--- a/tools/projective_transformation/projective_transformation.xml
+++ b/tools/projective_transformation/projective_transformation.xml
@@ -1,4 +1,4 @@
-<tool id="ip_projective_transformation" name="Performs projective transformation with/without labels" version="0.1.2-2" profile="20.05"> 
+<tool id="ip_projective_transformation" name="Perform projective transformation with/without labels" version="0.1.2-2" profile="20.05"> 
     <description></description>
     <edam_operations>
         <edam_operation>operation_3443</edam_operation>

--- a/tools/projective_transformation_points/projective_transformation_points.xml
+++ b/tools/projective_transformation_points/projective_transformation_points.xml
@@ -1,4 +1,4 @@
-<tool id="ip_projective_transformation_points" name="Performs projective transformation" license="MIT" version="0.1.1-2" profile="20.05">
+<tool id="ip_projective_transformation_points" name="Perform projective transformation" license="MIT" version="0.1.1-2" profile="20.05">
     <description></description>
     <edam_operations>
         <edam_operation>operation_3443</edam_operation>

--- a/tools/projective_transformation_points/projective_transformation_points.xml
+++ b/tools/projective_transformation_points/projective_transformation_points.xml
@@ -1,5 +1,9 @@
-<tool id="ip_projective_transformation_points" name="Perform projective transformation" license="MIT" version="0.1.1-2" profile="20.05">
+<tool id="ip_projective_transformation_points" name="Perform projective transformation" license="MIT" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="20.05">
     <description></description>
+    <macros>
+        <token name="@TOOL_VERSION@">0.1.1</token>
+        <token name="@VERSION_SUFFIX@">3</token>
+    </macros>
     <edam_operations>
         <edam_operation>operation_3443</edam_operation>
     </edam_operations>


### PR DESCRIPTION
Change the `Performs` in the name of the two tools

- `Performs projective transformation with/without labels`
- `Performs projective transformation`

to `Perform`. The imperative form is more consistent with

- the name of the other tools
- the community conventions

---

FOR CONTRIBUTOR:
* [x] - I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the galaxy-image-analysis repo.
* [x] - License permits unrestricted use (educational + commercial)
* [ ] - This PR adds a new tool or tool collection
* [x] - This PR updates an existing tool or tool collection
* [ ] - This PR does something else (explain below)
* [x] - Tools added/updated by this PR (if any) comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://github.com/elixir-europe/biohackathon-projects-2023/blob/main/16/conventions.md) (or please explain why they do not)
