### PR TITLE
Remove skip `tool_xsd`

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,6 @@ on:
       - '*'
 env:
   GALAXY_FORK: galaxyproject
-  # TODO remove additional-planemo-options from lint once biii is allowed in xsd
   GALAXY_BRANCH: release_23.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
@@ -130,12 +129,10 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         echo "FAIL_LEVEL=warn" >> "$GITHUB_ENV"
-        echo "SKIP=-s tool_xsd" >> "$GITHUB_ENV"
     - name: Set fail level for merge
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
-        echo "SKIP=-s tool_xsd" >> "$GITHUB_ENV"
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint

--- a/tools/superdsm/.shed.yml
+++ b/tools/superdsm/.shed.yml
@@ -2,7 +2,7 @@ categories:
   - Imaging
 description: Globally optimal segmentation method based on superadditivity and deformable shape models for cell nuclei in fluorescence microscopy images
 long_description: Globally optimal segmentation method based on superadditivity and deformable shape models for cell nuclei in 2-D fluorescence microscopy images.
-name: superdsm 
+name: superdsm
 owner: imgteam
 homepage_url: https://github.com/bmcv
 remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/superdsm/


### PR DESCRIPTION
Now that `planemo lint` passes locally and biii is allowed in xsd, it's time to revert f448ef9c89acd778122ba8ab2b63ab3bd3a57963.
