### PR TITLE
Add image verification support to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,6 +96,25 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
+#
+# ---------------------------------------------------------
+# This is a temporary addition to enable the features from
+# - https://github.com/galaxyproject/galaxy/pull/17556
+# - https://github.com/galaxyproject/galaxy/pull/17581
+#
+    - name: Planemo setup 
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: setup
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        tool-list: ${{ needs.setup.outputs.tool-list }}
+        additional-planemo-options: --biocontainers -s tests,output,inputs,help,general,command,citations,tool_xsd,xml_order,tool_urls,shed_metadata
+    - run: |
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/tool_util
+#
+# ---------------------------------------------------------
+#
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -150,6 +169,28 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
+#
+# ---------------------------------------------------------
+# This is a temporary addition to enable the features from
+# - https://github.com/galaxyproject/galaxy/pull/17556
+# - https://github.com/galaxyproject/galaxy/pull/17581
+#
+    - name: Planemo setup 
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: setup
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        galaxy-fork: ${{ needs.setup.outputs.fork }}
+        galaxy-branch: ${{ needs.setup.outputs.branch }}
+        chunk: ${{ matrix.chunk }}
+        chunk-count: ${{ needs.setup.outputs.chunk-count }}
+    - run: |
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/tool_util
+        python -m pip install pillow
+#
+# ---------------------------------------------------------
+#
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -133,6 +133,12 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
+#
+# ---------------------------------------------------------
+# This is a temporary addition to enable the features from
+# - https://github.com/galaxyproject/galaxy/pull/17556
+# - https://github.com/galaxyproject/galaxy/pull/17581
+#
     - name: Planemo setup 
       uses: galaxyproject/planemo-ci-action@v1
       with:
@@ -144,6 +150,9 @@ jobs:
     - run: |
         python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
         python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util
+#
+# ---------------------------------------------------------
+#
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -303,6 +312,26 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
+#
+# ---------------------------------------------------------
+# This is a temporary addition to enable the features from
+# - https://github.com/galaxyproject/galaxy/pull/17556
+# - https://github.com/galaxyproject/galaxy/pull/17581
+#
+    - name: Planemo setup 
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: setup
+        fail-level: ${{ env.FAIL_LEVEL }}
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        tool-list: ${{ needs.setup.outputs.tool-list }}
+        additional-planemo-options: ${{ env.SKIP }}
+    - run: |
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util
+#
+# ---------------------------------------------------------
+#
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -148,8 +148,8 @@ jobs:
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: ${{ env.SKIP }}
     - run: |
-        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
-        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/tool_util
 #
 # ---------------------------------------------------------
 #
@@ -327,8 +327,8 @@ jobs:
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: ${{ env.SKIP }}
     - run: |
-        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@asserts_image/fix#subdirectory=packages/util
-        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@asserts_image/fix#subdirectory=packages/tool_util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/tool_util
         python -m pip install pillow
 #
 # ---------------------------------------------------------

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -327,8 +327,8 @@ jobs:
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: ${{ env.SKIP }}
     - run: |
-        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
-        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util
+        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@asserts_image/fix#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@asserts_image/fix#subdirectory=packages/tool_util
         python -m pip install pillow
 #
 # ---------------------------------------------------------

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -137,6 +137,10 @@ jobs:
       uses: galaxyproject/planemo-ci-action@v1
       with:
         mode: setup
+        fail-level: ${{ env.FAIL_LEVEL }}
+        repository-list: ${{ needs.setup.outputs.repository-list }}
+        tool-list: ${{ needs.setup.outputs.tool-list }}
+        additional-planemo-options: ${{ env.SKIP }}
     - run: |
         python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
         python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -133,6 +133,13 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
+    - name: Planemo setup 
+      uses: galaxyproject/planemo-ci-action@v1
+      with:
+        mode: setup
+    - run: |
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
+        python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -329,6 +329,7 @@ jobs:
     - run: |
         python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/util
         python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@dev#subdirectory=packages/tool_util
+        python -m pip install pillow
 #
 # ---------------------------------------------------------
 #


### PR DESCRIPTION
**For the contributor:**
* [x] I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document.
* [x] License permits unrestricted use (educational + commercial).
* [ ] This PR adds or updates a tool or tool collection.
  * [ ] This PR adds a new tool or tool collection.
  * [ ] This PR updates an existing tool or tool collection.
  * [ ] Tools added/updated by this PR comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://github.com/elixir-europe/biohackathon-projects-2023/blob/main/16/paper/paper.md#conventions) (or explain why they do not).
* [x] This PR does something else (explain below).

---

This PR adds the image verification support from https://github.com/galaxyproject/galaxy/pull/17581 and https://github.com/galaxyproject/galaxy/pull/17556, until the new features become available in a recent Galaxy release.

This temporary change to the CI essentially adds the instructions
```bash
python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/util
python -m pip install git+https://git@github.com/galaxyproject/galaxy.git@5c1d045ce7b1e45f85608346baed5455324ee967#subdirectory=packages/tool_util
```
before linting and testing, and, in addition,
```bash
python -m pip install pillow
```
before testing.

The commit hash [`5c1d045ce7b1e45f85608346baed5455324ee967`](https://github.com/galaxyproject/galaxy/commit/5c1d045ce7b1e45f85608346baed5455324ee967) corresponds to the latest merged bug fix.