### PR TITLE
Update ip_imageinfo, update CI to release_24.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ on:
   repository_dispatch:
     types: [run-all-tool-tests-command]
 env:
-  GALAXY_FORK: kostrykin  # Temporary change to enable the features from https://github.com/galaxyproject/galaxy/pull/17556 and https://github.com/galaxyproject/galaxy/pull/17581
-  GALAXY_BRANCH: galaxy-image-analysis  # Temporary change to enable the features from https://github.com/galaxyproject/galaxy/pull/17556 and https://github.com/galaxyproject/galaxy/pull/17581
+  GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: release_24.1
   MAX_CHUNKS: 40
 jobs:
   setup:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,25 +96,6 @@ jobs:
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-#
-# ---------------------------------------------------------
-# This is a temporary addition to enable the features from
-# - https://github.com/galaxyproject/galaxy/pull/17556
-# - https://github.com/galaxyproject/galaxy/pull/17581
-#
-    - name: Planemo setup 
-      uses: galaxyproject/planemo-ci-action@v1
-      with:
-        mode: setup
-        repository-list: ${{ needs.setup.outputs.repository-list }}
-        tool-list: ${{ needs.setup.outputs.tool-list }}
-        additional-planemo-options: --biocontainers -s tests,output,inputs,help,general,command,citations,tool_xsd,xml_order,tool_urls,shed_metadata
-    - run: |
-        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/util
-        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/tool_util
-#
-# ---------------------------------------------------------
-#
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -169,28 +150,6 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
-#
-# ---------------------------------------------------------
-# This is a temporary addition to enable the features from
-# - https://github.com/galaxyproject/galaxy/pull/17556
-# - https://github.com/galaxyproject/galaxy/pull/17581
-#
-    - name: Planemo setup 
-      uses: galaxyproject/planemo-ci-action@v1
-      with:
-        mode: setup
-        repository-list: ${{ needs.setup.outputs.repository-list }}
-        galaxy-fork: ${{ needs.setup.outputs.fork }}
-        galaxy-branch: ${{ needs.setup.outputs.branch }}
-        chunk: ${{ matrix.chunk }}
-        chunk-count: ${{ needs.setup.outputs.chunk-count }}
-    - run: |
-        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/util
-        python -m pip install git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/tool_util
-        python -m pip install pillow tifffile
-#
-# ---------------------------------------------------------
-#
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,8 +16,8 @@ on:
       - 'docs/**'
       - '*'
 env:
-  GALAXY_FORK: kostrykin  # Temporary change to enable the features from https://github.com/galaxyproject/galaxy/pull/17556 and https://github.com/galaxyproject/galaxy/pull/17581
-  GALAXY_BRANCH: galaxy-image-analysis  # Temporary change to enable the features from https://github.com/galaxyproject/galaxy/pull/17556 and https://github.com/galaxyproject/galaxy/pull/17581
+  GALAXY_FORK: galaxyproject
+  GALAXY_BRANCH: release_24.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -133,18 +133,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' }}
       run: |
         echo "FAIL_LEVEL=error" >> "$GITHUB_ENV"
-#
-# ---------------------------------------------------------
-# This is a temporary addition to enable the features from
-# - https://github.com/galaxyproject/galaxy/pull/17556
-# - https://github.com/galaxyproject/galaxy/pull/17581
-#
-    - run: |
-        python -m pip install --no-dependencies git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/util
-        python -m pip install --no-dependencies git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/tool_util
-#
-# ---------------------------------------------------------
-#
+
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -304,19 +293,6 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
-#
-# ---------------------------------------------------------
-# This is a temporary addition to enable the features from
-# - https://github.com/galaxyproject/galaxy/pull/17556
-# - https://github.com/galaxyproject/galaxy/pull/17581
-#
-    - run: |
-        python -m pip install --no-dependencies git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/util
-        python -m pip install --no-dependencies git+https://git@github.com/kostrykin/galaxy.git@galaxy-image-analysis#subdirectory=packages/tool_util
-        python -m pip install pillow tifffile
-#
-# ---------------------------------------------------------
-#
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/tools/image_info/image_info.xml
+++ b/tools/image_info/image_info.xml
@@ -1,4 +1,4 @@
-<tool id="ip_imageinfo" name="Show image info" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="ip_imageinfo" name="Show image info" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="23.0">
   <description>with Bioformats</description>
   <macros>
     <token name="@TOOL_VERSION@">5.7.1</token>

--- a/tools/image_info/image_info.xml
+++ b/tools/image_info/image_info.xml
@@ -1,5 +1,9 @@
-<tool id="ip_imageinfo" name="Show image info" version="5.7.1">
+<tool id="ip_imageinfo" name="Show image info" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
   <description>with Bioformats</description>
+  <macros>
+    <token name="@TOOL_VERSION@">5.7.1</token>
+    <token name="@VERSION_SUFFIX@">1</token>
+  </macros>
   <edam_operations>
     <edam_operation>operation_3443</edam_operation>
   </edam_operations>
@@ -7,7 +11,7 @@
     <xref type="biii">python-bioformats</xref>
   </xrefs>
   <requirements>
-        <requirement type="package" version="5.7.1">bftools</requirement>
+        <requirement type="package" version="@TOOL_VERSION@">bftools</requirement>
   </requirements>
   <command> 
         <![CDATA[


### PR DESCRIPTION
If admins set `_JAVA_OPTIONS` the stderr will contain `Picked up _JAVA_OPTIONS: -Xmx6g -Xms256m`. For legacy tools (without profile) any text in the stderr will make the tool fail.

---

**FOR THE CONTRIBUTOR — Please fill out if applicable**

Please make sure you have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2024/04/23).

* [ ] License permits unrestricted use (educational + commercial).

If this PR adds or updates a tool or tool collection:

* [ ] This PR adds a new tool or tool collection.
* [ ] This PR updates an existing tool or tool collection.
* [ ] Tools added/updated by this PR comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://doi.org/10.37044/osf.io/w8dsz) (or explain why they do not).
