### PR TITLE
Install pillow tifffile in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,7 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
+    - run: python -m pip install pillow tifffile
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -293,6 +293,7 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
+    - run: python -m pip install pillow tifffile
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test


### PR DESCRIPTION
In #124, the step `python -m pip install pillow tifffile` was removed, which causes the error

> pillow and tifffile are not installed, but required to compare files using the 'image_diff' method

in subsequent PRs (e.g., #125).

This PR adds the step `python -m pip install pillow tifffile` back.