### PR TITLE
Remove `python -m pip install pillow tifffile` from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,6 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
-    - run: python -m pip install pillow tifffile
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -293,7 +293,6 @@ jobs:
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
-    - run: python -m pip install pillow tifffile
     - name: Planemo test
       uses: galaxyproject/planemo-ci-action@v1
       id: test

--- a/tools/background_removal/.shed.yml
+++ b/tools/background_removal/.shed.yml
@@ -1,4 +1,4 @@
-categories:
+categories: 
   - Imaging
 description: Background removal filters using scikit-image
 long_description: Tool to perform a background removal using 1) Rolling-Ball Algorithm, 2) Difference of Gaussians and 3) Top-Hat Filter


### PR DESCRIPTION
This was added back in https://github.com/BMCV/galaxy-image-analysis/pull/126

but should be obsolete after https://github.com/galaxyproject/planemo/pull/1471