### PR TITLE
Fix dependencies of `overlay_images` tool

### DIFF
--- a/tools/overlay_images/overlay_images.xml
+++ b/tools/overlay_images/overlay_images.xml
@@ -21,6 +21,7 @@
         <requirement type="package" version="3.3.4">matplotlib</requirement>
         <requirement type="package" version="2020.10.1">tifffile</requirement>
         <requirement type="package" version="1.21">numpy</requirement>
+        <requirement type="package" version="10.4.0">pillow</requirement>
         <requirement type="package" version="0.1">giatools</requirement>
     </requirements>
     <command detect_errors="aggressive">

--- a/tools/overlay_images/overlay_images.xml
+++ b/tools/overlay_images/overlay_images.xml
@@ -61,7 +61,7 @@
             </when>
             <when value="seg_contour">
                 <param name="im1" type="data" format="tiff,png" label="Intensity image" />
-                <param name="im2" type="data" format="tiff,png" label="Label image" />
+                <param name="im2" type="data" format="tiff,png" label="Label map" />
                 <param name="thickness" type="integer" value="2" min="1" label="Contour thickness (in pixels)" />
                 <param name="color" type="color" value="#ff0000" label="Contour color"/>
                 <param argument="--show_label" type="boolean" checked='false' truevalue="--show_label" falsevalue="" label="Show labels" />

--- a/tools/overlay_images/overlay_images.xml
+++ b/tools/overlay_images/overlay_images.xml
@@ -4,7 +4,7 @@
         <import>creators.xml</import>
         <import>tests.xml</import>
         <token name="@TOOL_VERSION@">0.0.4</token>
-        <token name="@VERSION_SUFFIX@">3</token>
+        <token name="@VERSION_SUFFIX@">4</token>
     </macros>
     <creator>
         <expand macro="creators/bmcv"/>
@@ -20,7 +20,7 @@
         <requirement type="package" version="0.18.1">scikit-image</requirement> 
         <requirement type="package" version="3.3.4">matplotlib</requirement>
         <requirement type="package" version="2020.10.1">tifffile</requirement>
-        <requirement type="package" version="1.20.2">numpy</requirement>
+        <requirement type="package" version="1.21">numpy</requirement>
         <requirement type="package" version="0.1">giatools</requirement>
     </requirements>
     <command detect_errors="aggressive">


### PR DESCRIPTION
Previous versions of the tool required numpy 1.20, that does not offer the `numpy.typing` package.

One of the other dependencies of the tool is scikit-image, which in turn requires pillow. When testing without containerization (i.e. without the `--biocontainers` switch), the tests failed, because seemingly a newer version of pillow was installed (10.4.0, compared to testing with containerization). However, pillow 10.4.0 requires the `numpy.typing` package, that isn't there with numpy 1.20:

> AttributeError: module 'numpy.typing' has no attribute 'NDArray'

The same issue could be reproduced by running a local Galaxy instance without containerization (which is very much the procedure suggested in https://galaxyproject.org/admin/get-galaxy).

To fix these issues, this PR bumps numpy to 1.21 (which includes the `numpy.typing` package) and pins pillow to 10.4.0 (to prevent similar issues in the future).

Could be related to #121.

---

**FOR THE CONTRIBUTOR — Please fill out if applicable**

Please make sure you have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2024/04/23).

* [x] License permits unrestricted use (educational + commercial).

If this PR adds or updates a tool or tool collection:

* [ ] This PR adds a new tool or tool collection.
* [x] This PR updates an existing tool or tool collection.
* [x] Tools added/updated by this PR comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://doi.org/10.37044/osf.io/w8dsz) (or explain why they do not).
