### PR TITLE
Accept `tiff` input data in `scale_image` tool

### DIFF
--- a/tools/scale_image/scale_image.xml
+++ b/tools/scale_image/scale_image.xml
@@ -4,7 +4,7 @@
         <import>creators.xml</import>
         <import>tests.xml</import>
         <token name="@TOOL_VERSION@">0.18.3</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <creator>
         <expand macro="creators/bmcv" />
@@ -37,7 +37,7 @@
 
     ]]></command>
     <inputs>
-        <param name="input" type="data" format="png" label="Image file"/>
+        <param name="input" type="data" format="png,tiff" label="Image file"/>
         <param argument="--scale" type="text" value="1" label="Scaling factor" help="Use either a single scaling factor (uniform scaling), or a comma-separated list of scaling factors (anistropic scaling). For a 2-D single-channel or RGB image, the first scaling factor corresponds to the image width and the second corresponds to the image height. For images with 3 or more axes, the last axis is assumed to correspond to the image channels if uniform scaling is used (a single value)."/>
         <param argument="--order" type="select" label="Interpolation method">
             <option value="0">Nearest-neighbor</option>


### PR DESCRIPTION
The `scale_image` tool was only accepting PNG files:
https://github.com/BMCV/galaxy-image-analysis/blob/5bf3d886edf4c695daf53a29809a5a88e5ece3ac/tools/scale_image/scale_image.xml#L40

Strangely, there already were tests for TIFF files _and they passed_ despite the `format="png"` attribute:
https://github.com/BMCV/galaxy-image-analysis/blob/5bf3d886edf4c695daf53a29809a5a88e5ece3ac/tools/scale_image/scale_image.xml#L80

Is this a bug in the testing framework?

This PR fixes the `format` attribute so that TIFF files are also accepted (tests are already there).

cc @dianichj

---

**FOR THE CONTRIBUTOR — Please fill out if applicable**

Please make sure you have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2024/04/23).

* [x] License permits unrestricted use (educational + commercial).

If this PR adds or updates a tool or tool collection:

* [ ] This PR adds a new tool or tool collection.
* [x] This PR updates an existing tool or tool collection.
* [x] Tools added/updated by this PR comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://doi.org/10.37044/osf.io/w8dsz) (or explain why they do not).
