### PR TITLE
Fix `remote_repository_url` of `color_deconvolution` tool

### DIFF
--- a/tools/color_deconvolution/.shed.yml
+++ b/tools/color_deconvolution/.shed.yml
@@ -5,4 +5,4 @@ long_description: This tools does color space transformation using preset transf
 name: color_deconvolution 
 owner: imgteam
 homepage_url: https://github.com/bmcv
-remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/color-deconvolution/
+remote_repository_url: https://github.com/BMCV/galaxy-image-analysis/tree/master/tools/color_deconvolution/

--- a/tools/color_deconvolution/color_deconvolution.xml
+++ b/tools/color_deconvolution/color_deconvolution.xml
@@ -1,4 +1,4 @@
-<tool id="ip_color_deconvolution" name="Perform color decomposition" version="0.8-2"> 
+<tool id="ip_color_deconvolution" name="Perform color decomposition" version="0.8-3"> 
     <description></description>
     <edam_operations>
         <edam_operation>operation_3443</edam_operation>


### PR DESCRIPTION
Fix `remote_repository_url` of `color_deconvolution` tool.

I wasn't sure whether it's worth incrementing the version for such a small change. On the other hand, it's nice to have the `remote_repository_url ` set correctly.

---

**FOR THE CONTRIBUTOR — Please fill out if applicable**

Please make sure you have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2024/04/23).

* [x] License permits unrestricted use (educational + commercial).

If this PR adds or updates a tool or tool collection:

* [ ] This PR adds a new tool or tool collection.
* [x] This PR updates an existing tool or tool collection.
* [x] Tools added/updated by this PR comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://doi.org/10.37044/osf.io/w8dsz) (or explain why they do not).
