### PR TITLE
Fix support for files without extensions in unzip tool

### DIFF
--- a/tools/unzip/unzip.xml
+++ b/tools/unzip/unzip.xml
@@ -2,7 +2,7 @@
     <description>Unzip a file</description>
     <macros>
         <token name="@TOOL_VERSION@">6.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">22.01</token>
     </macros>
     <requirements>

--- a/tools/unzip/unzip.xml
+++ b/tools/unzip/unzip.xml
@@ -42,7 +42,7 @@
                 <option selected="True" value="True">All files</option>
                 <option value="False">Single file</option>
             </param>
-            <when value="True"></when>
+            <when value="True"/>
             <when value="False">
                 <param name="pathtofile" type="text" value="" label="Filepath">
                     <validator type="expression" message="No two dots (..) allowed">'..' not in value</validator>
@@ -63,15 +63,19 @@
         </collection>
     </outputs>
     <tests>
-       <test expect_num_outputs="1">
+        <test expect_num_outputs="1">
             <param name="input_file" value="input.zip" ftype="zip"/>
-            <param name="extract_all" value="False"/>
-            <param name="pathtofile" value="input.png"/>
+            <conditional name="extract_options">
+                <param name="extract_all" value="False"/>
+                <param name="pathtofile" value="input.png"/>
+            </conditional>
             <output name="unzipped_single" file="input.png" ftype="png" compare="sim_size"/>
         </test>
         <test expect_num_outputs="1">
             <param name="input_file" value="input.zip" ftype="zip"/>
-            <param name="extract_all" value="True"/>
+            <conditional name="extract_options">
+                <param name="extract_all" value="True"/>
+            </conditional>
             <output_collection name="unzipped" type="list" count="2">
                 <element name="input" file="input.png" ftype="png" compare="sim_size"/>
                 <element name="res" file="res.tiff" ftype="tiff" compare="sim_size"/>
@@ -80,7 +84,9 @@
         <!-- Binary files without file extension -->
         <test expect_num_outputs="1">
             <param name="input_file" value="input_binary.zip" ftype="zip"/>
-            <param name="extract_all" value="True"/>
+            <conditional name="extract_options">
+                <param name="extract_all" value="True"/>
+            </conditional>
             <output_collection name="unzipped" type="list" count="2">
                 <element name="yelp" file="yelp" compare="sim_size"/>
                 <element name="yes" file="yes" compare="sim_size"/>
@@ -89,7 +95,9 @@
         <!-- Compressed object with subfolders, each containing files -->
         <test expect_num_outputs="1">
             <param name="input_file" value="subfolders.zip" ftype="zip"/>
-            <param name="extract_all" value="True"/>
+            <conditional name="extract_options">
+                <param name="extract_all" value="True"/>
+            </conditional>
             <output_collection name="unzipped" type="list" count="4">
                 <element name="binaries_yelp" file="yelp" compare="sim_size"/>
                 <element name="binaries_yes" file="yes" compare="sim_size"/>
@@ -99,19 +107,23 @@
         </test>
         <test expect_num_outputs="1">
             <param name="input_file" value="input.tar" ftype="tar"/>
-            <param name="extract_all" value="False"/>
-            <param name="pathtofile" value="input.png"/>
+            <conditional name="extract_options">
+                <param name="extract_all" value="False"/>
+                <param name="pathtofile" value="input.png"/>
+            </conditional>
             <output name="unzipped_single" file="input.png" ftype="png" compare="sim_size"/>
         </test>
         <test expect_num_outputs="1">
             <param name="input_file" value="input.tar" ftype="tar"/>
-            <param name="extract_all" value="True"/>
+            <conditional name="extract_options">
+                <param name="extract_all" value="True"/>
+            </conditional>
             <output_collection name="unzipped" type="list" count="2">
                 <element name="input" file="input.png" ftype="png" compare="sim_size"/>
                 <element name="res" file="res.tiff" ftype="tiff" compare="sim_size"/>
             </output_collection>
         </test>
-    </tests>   
+    </tests>
     <help>
         **What it does**
           
@@ -121,4 +133,3 @@
         <citation type="doi">10.1016/j.jbiotec.2017.07.019</citation>
     </citations>
 </tool>
-

--- a/tools/unzip/unzip.xml
+++ b/tools/unzip/unzip.xml
@@ -58,8 +58,7 @@
             <filter>extract_options['extract_all'] == 'False'</filter>
         </data>
         <collection name="unzipped" type="list" label="${tool.name} on ${on_string} all files as collection">
-            <discover_datasets directory="out" pattern="(?P&lt;designation&gt;.+?)(\.(?P&lt;ext&gt;[^\._]+))?$" visible="false" format="auto"/>
-            <!--      pattern=__designation_and_ext__ = (?P&lt;designation&gt;.*)\.(?P&lt;ext&gt;[^\._]+)? would discard files without extensions -->
+            <discover_datasets directory="out" pattern="(?P&lt;designation&gt;\.*[^\.]+)\.?(?P&lt;ext&gt;.*)" visible="false" format="auto"/>
             <filter>extract_options['extract_all'] == 'True'</filter>
         </collection>
     </outputs>


### PR DESCRIPTION
#53 added https://github.com/BMCV/galaxy-image-analysis/pull/53/commits/e8e1f67d811bf788138b5c8463ea4e7f391e7277 which aimed to _"tolerate files without extension"_, but corresponding tests have been failing recently:
> Test 3: Output collection 'unzipped': expected to have 2 elements, but it had 0.
> Test 4: Output collection 'unzipped': expected to have 4 elements, but it had 0.

**Test 3** concerns files that have no extensions:
https://github.com/BMCV/galaxy-image-analysis/blob/f20ae636930eec5ce230e69a8b51f5dceee56cb9/tools/unzip/unzip.xml#L85-L88

**Test 4** concerns a combination of files that have extensions and have no extensions:
https://github.com/BMCV/galaxy-image-analysis/blob/f20ae636930eec5ce230e69a8b51f5dceee56cb9/tools/unzip/unzip.xml#L94-L99

Interestingly, the presence of files without extensions also prevents the files with extensions from being detected.

After some digging into this I came to the conclusion, that this behavior is caused by the regex employed in https://github.com/BMCV/galaxy-image-analysis/pull/53/commits/e8e1f67d811bf788138b5c8463ea4e7f391e7277:
```
(?P<designation>.+?)(\.(?P<ext>[^\._]+))?$
```
Here, the capture group `ext` is _omitted_ if there is no extension, which seems to be handled differently by Galaxy internals than if the capture group is empty. This would explain the failure of Test 3, but I have no clue why this confuses Galaxy so much that it also causes failure of Test 4 (_"expected to have 4 elements, but it had 0."_).

Nevertheless, changing the regex to
```
(?P<designation>\.*[^\.]+)\.?(?P<ext>.*)
```
as I did in 1d86bc61359e5c34ef415b348708241dc8416f7f fixes the issue and makes the tests pass.

I believe that the new regex is also more robust and consistent in the following sense:

<table>
  <tr>
    <td>&nbsp;</td>
    <td colspan="2"><b>Old: (?P&lt;designation&gt;.+?)(\.(?P&lt;ext&gt;[^\._]+))?$</b></td>
    <td colspan="2"><b>New: (?P&lt;designation&gt;\.*[^\.]+)\.?(?P&lt;ext&gt;.*)</b></td>
  </tr>
  <tr>
    <td>&nbsp;</td>
    <td>designation</td>
    <td>ext</td>
    <td>designation</td>
    <td>ext</td>
  </tr>
  <tr>
    <td>filename</td>
    <td>✅ filename</td>
    <td>✅ &ndash;</td>
    <td>✅ filename</td>
    <td>✅ &ndash;</td>
  </tr>
  <tr>
    <td>filename.</td>
    <td>❌ filename.</td>
    <td>✅ &ndash;</td>
    <td>✅ filename</td>
    <td>✅ &ndash;</td>
  </tr>
  <tr>
    <td>.filename</td>
    <td>✅ .filename</td>
    <td>✅ &ndash;</td>
    <td>✅ .filename</td>
    <td>✅ &ndash;</td>
  </tr>
  <tr>
    <td>filename.ext</td>
    <td>✅ filename</td>
    <td>✅ ext</td>
    <td>✅ filename</td>
    <td>✅ ext</td>
  </tr>
  <tr>
    <td>filename.e.xt</td>
    <td>❌ filename.e</td>
    <td>❌ xt</td>
    <td>✅ filename</td>
    <td>✅ e.xt</td>
  </tr>
</table>

cc @tuncK 

---

**FOR THE CONTRIBUTOR — Please fill out if applicable**

Please make sure you have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2024/04/23).

* [x] License permits unrestricted use (educational + commercial).

If this PR adds or updates a tool or tool collection:

* [ ] This PR adds a new tool or tool collection.
* [x] This PR updates an existing tool or tool collection.
* [x] Tools added/updated by this PR comply with the [Naming and Annotation Conventions for Tools in the Image Community in Galaxy](https://doi.org/10.37044/osf.io/w8dsz) (or explain why they do not).
