### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -100,18 +100,19 @@ jobs:
       run: |
         echo 'Using ${{ steps.discover.outputs.chunk-count }} chunks (${{ steps.discover.outputs.chunk-list }})'
 
-  # Check latest commit for potential switches
+  # Check latest commit for potential switches (only for pull_request events)
   commit_switches:
     name: Check latest commit
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
     outputs:
       skip_version_check: ${{ steps.checks.outputs.skip_version_check }}
     steps:
     - name: Get latest commit SHA
+      if: ${{ github.event_name == 'pull_request' }}
       id: pr
       run: echo "sha=$(jq -r .pull_request.head.sha < $GITHUB_EVENT_PATH)" >> $GITHUB_OUTPUT
     - name: Get commit message
+      if: ${{ github.event_name == 'pull_request' }}
       id: commit
       run: |
         COMMIT_MSG=$(gh api repos/${{ github.repository }}/commits/${{ steps.pr.outputs.sha }} --jq .commit.message)
@@ -121,13 +122,17 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
     - name: Check for "[skip-version-check]" in commit message
-      id: checks
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         echo "Commit Message: ${{ steps.commit.outputs.commit_message }}"
         shopt -s nocasematch
         if [[ "${{ steps.commit.outputs.commit_message }}" == *"[skip-version-check]"* ]]; then
-          echo "skip_version_check=true" >> $GITHUB_OUTPUT
+          echo "SKIP_VERSION_CHECK=true" >> $GITHUB_ENV
         fi
+    - name: Set job outputs
+      id: checks
+      run: |
+          echo "skip_version_check=${SKIP_VERSION_CHECK}" >> $GITHUB_OUTPUT
 
   # Planemo lint the changed repositories
   lint:

--- a/tools/unzip/.shed.yml
+++ b/tools/unzip/.shed.yml
@@ -1,4 +1,4 @@
-categories:
+categories: 
   - Convert Formats
 description: Unzip file
 long_description: Unzip file to collection

--- a/tools/unzip/unzip.xml
+++ b/tools/unzip/unzip.xml
@@ -2,7 +2,7 @@
     <description>Unzip a file</description>
     <macros>
         <token name="@TOOL_VERSION@">6.0</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
         <token name="@PROFILE@">22.01</token>
     </macros>
     <requirements>

--- a/tools/unzip/unzip.xml
+++ b/tools/unzip/unzip.xml
@@ -2,7 +2,7 @@
     <description>Unzip a file</description>
     <macros>
         <token name="@TOOL_VERSION@">6.0</token>
-        <token name="@VERSION_SUFFIX@">2</token>
+        <token name="@VERSION_SUFFIX@">1</token>
         <token name="@PROFILE@">22.01</token>
     </macros>
     <requirements>


### PR DESCRIPTION
https://github.com/BMCV/galaxy-image-analysis/pull/152 introduced a bug in the CI, that prevents CI from running properly when merging to the main branch. This is because in #152 a dependency of the `lint` job was added, that is `commit_switches`, but the latter only runs if `github.event_name == 'pull_request'`. Thus, for push events, both `lint` and `commit_switches` are skipped: https://github.com/BMCV/galaxy-image-analysis/actions/runs/16537671078/job/47915204250

This PR updates the CI so that the `commit_switches` job also runs for push events, but instead its steps are skipped. 