### PR TITLE
Update `ip_points2label`

### DIFF
--- a/tools/points2labelimage/points2label.py
+++ b/tools/points2labelimage/points2label.py
@@ -252,9 +252,11 @@ if __name__ == '__main__':
     parser.add_argument('out_file', type=str, help='Output file path (TIFF)')
     parser.add_argument('shapex', type=int, help='Output image width')
     parser.add_argument('shapey', type=int, help='Output image height')
-    parser.add_argument('--has_header', dest='has_header', default=False, help='Set True if tabular file has a header')
-    parser.add_argument('--swap_xy', dest='swap_xy', default=False, help='Swap X and Y coordinates')
-    parser.add_argument('--binary', dest='binary', default=False, help='Produce binary image')
+    parser.add_argument('--bg_value', type=int, default=0, help='Label used for image background')
+    parser.add_argument('--has_header', default=False, help='Set if tabular file has a header', action='store_true')
+    parser.add_argument('--swap_xy', default=False, help='Swap X and Y coordinates', action='store_true')
+    parser.add_argument('--binary', default=False, help='Produce binary image', action='store_true')
+    parser.add_argument('--split', default=False, help='Split rasterizations into one file per object', action='store_true')
     args = parser.parse_args()
 
     # Determine target shape
@@ -275,14 +277,22 @@ if __name__ == '__main__':
             geojson = json.load(f)
 
     # Rasterize the image from GeoJSON
-    bg_value = 0
-    img = np.full(shape, dtype=np.uint16, fill_value=bg_value)
+    img = None
     for mask, label in rasterize(
         geojson,
         shape,
+        bg_value=args.bg_value,
         fg_value=0xffff if args.binary else None,
     ):
+        if args.split or img is None:
+            img = np.full(shape, dtype=np.uint16, fill_value=args.bg_value)
+
+        # Blend the rasterization into the target image
         img[mask] = label
+
+        # TODO: write image to file if `args.split`
+
+    # Swap axes if requested
     if args.swap_xy:
         img = img.T
 

--- a/tools/points2labelimage/points2label.py
+++ b/tools/points2labelimage/points2label.py
@@ -53,11 +53,11 @@ class AutoLabel:
             self.next_autolabel += 1
 
 
-def get_feature_label(feature: Dict) -> Optional[int]:
+def get_feature_label(feature: Dict, label_property: str) -> Optional[int]:
     """
     Get the label of a GeoJSON feature, or `None` if there is no proper label.
     """
-    label = feature.get('properties', {}).get('name', None)
+    label = feature.get('properties', {}).get(label_property, None)
     if label is None:
         return None
 
@@ -80,6 +80,7 @@ def rasterize(
     shape: Tuple[int, int],
     bg_value: int = 0,
     fg_value: Optional[int] = None,
+    label_property: str = 'name',
 ) -> Iterator[Tuple[npt.NDArray, int]]:
     """
     Rasterize GeoJSON into a pixel image, that is returned as a NumPy array.
@@ -89,7 +90,7 @@ def rasterize(
     reserved_labels = [bg_value]
     if fg_value is None:
         for feature in geojson['features']:
-            label = get_feature_label(feature)
+            label = get_feature_label(feature, label_property)
             if label is not None:
                 reserved_labels.append(label)
 
@@ -134,7 +135,7 @@ def rasterize(
 
         # Determine the `label` for the current `mask`
         if fg_value is None:
-            label = get_feature_label(feature)
+            label = get_feature_label(feature, label_property)
             if label is None:
                 label = autolabel.next()
         else:
@@ -253,6 +254,7 @@ if __name__ == '__main__':
     parser.add_argument('shapex', type=int, help='Output image width')
     parser.add_argument('shapey', type=int, help='Output image height')
     parser.add_argument('--bg_value', type=int, default=0, help='Label used for image background')
+    parser.add_argument('--label_property', type=str, default='name', help='GeoJSON property used as labels')
     parser.add_argument('--has_header', default=False, help='Set if tabular file has a header', action='store_true')
     parser.add_argument('--swap_xy', default=False, help='Swap X and Y coordinates', action='store_true')
     parser.add_argument('--binary', default=False, help='Produce binary image', action='store_true')
@@ -283,6 +285,7 @@ if __name__ == '__main__':
         shape,
         bg_value=args.bg_value,
         fg_value=0xffff if args.binary else None,
+        label_property=args.label_property,
     ):
         if args.split or img is None:
             img = np.full(shape, dtype=np.uint16, fill_value=args.bg_value)

--- a/tools/points2labelimage/points2label.py
+++ b/tools/points2labelimage/points2label.py
@@ -4,6 +4,7 @@ import warnings
 from typing import (
     Any,
     Dict,
+    Iterator,
     Optional,
     Tuple,
 )
@@ -79,7 +80,7 @@ def rasterize(
     shape: Tuple[int, int],
     bg_value: int = 0,
     fg_value: Optional[int] = None,
-) -> npt.NDArray:
+) -> Iterator[Tuple[npt.NDArray, int]]:
     """
     Rasterize GeoJSON into a pixel image, that is returned as a NumPy array.
     """
@@ -99,7 +100,6 @@ def rasterize(
     autolabel = AutoLabel(reserved_labels)
 
     # Rasterize the image
-    img = np.full(shape, dtype=np.uint16, fill_value=bg_value)
     for feature in geojson['features']:
         geom_type = feature['geometry']['type'].lower()
         coords = feature['geometry']['coordinates']
@@ -140,11 +140,8 @@ def rasterize(
         else:
             label = fg_value
 
-        # Blend the current `mask` with the rasterized image
-        img[mask] = label
-
-    # Return the rasterized image
-    return img
+        # Yield the current `mask` and `label`
+        yield mask, label
 
 
 def convert_tabular_to_geojson(
@@ -260,6 +257,11 @@ if __name__ == '__main__':
     parser.add_argument('--binary', dest='binary', default=False, help='Produce binary image')
     args = parser.parse_args()
 
+    # Determine target shape
+    shape = (args.shapey, args.shapex)
+    if args.swap_xy:
+        shape = shape[::-1]
+
     # Validate command-line arguments
     assert args.in_ext in ('tabular', 'geojson'), (
         f'Unexpected input file format: {args.in_ext}'
@@ -273,12 +275,13 @@ if __name__ == '__main__':
             geojson = json.load(f)
 
     # Rasterize the image from GeoJSON
-    shape = (args.shapey, args.shapex)
-    img = rasterize(
+    img = np.full(shape, dtype=np.uint16, fill_value=bg_value)
+    for mask, label in rasterize(
         geojson,
-        shape if not args.swap_xy else shape[::-1],
+        shape,
         fg_value=0xffff if args.binary else None,
-    )
+    ):
+        img[mask] = label
     if args.swap_xy:
         img = img.T
 

--- a/tools/points2labelimage/points2label.py
+++ b/tools/points2labelimage/points2label.py
@@ -275,6 +275,7 @@ if __name__ == '__main__':
             geojson = json.load(f)
 
     # Rasterize the image from GeoJSON
+    bg_value = 0
     img = np.full(shape, dtype=np.uint16, fill_value=bg_value)
     for mask, label in rasterize(
         geojson,

--- a/tools/points2labelimage/points2label.xml
+++ b/tools/points2labelimage/points2label.xml
@@ -32,9 +32,9 @@
         $shapex
         $shapey
 
-        --has_header
-        --swap_xy
-        --binary
+        $has_header
+        $swap_xy
+        $binary
 
     ]]></command>
     <inputs>

--- a/tools/points2labelimage/points2label.xml
+++ b/tools/points2labelimage/points2label.xml
@@ -24,14 +24,25 @@
     <command detect_errors="aggressive"><![CDATA[
 
         python '$__tool_directory__/points2label.py'
+
         '$input.file_ext'
         '$input'
         '$output'
+
         $shapex
         $shapey
-        $has_header
-        $swap_xy
-        $binary
+
+        #if $has_header
+            --has_header
+        #end if
+
+        #if $swap_xy
+            --swap_xy
+        #end if
+
+        #if $binary
+            --binary
+        #end if
 
     ]]></command>
     <inputs>

--- a/tools/points2labelimage/points2label.xml
+++ b/tools/points2labelimage/points2label.xml
@@ -3,7 +3,7 @@
     <macros>
         <import>creators.xml</import>
         <import>tests.xml</import>
-        <token name="@TOOL_VERSION@">0.5.0</token>
+        <token name="@TOOL_VERSION@">0.6.0</token>
     </macros>
     <creator>
         <expand macro="creators/bmcv" />
@@ -32,26 +32,21 @@
         $shapex
         $shapey
 
-        #if $has_header
-            --has_header
-        #end if
-
-        #if $swap_xy
-            --swap_xy
-        #end if
-
-        #if $binary
-            --binary
-        #end if
+        --has_header
+        --swap_xy
+        --binary
 
     ]]></command>
     <inputs>
         <param name="input" type="data" format="tabular,geojson" label="Shapes to be rasterized"/>
-        <param name="shapex" type="integer" value="500" min="1" label="Width of the output image" />
-        <param name="shapey" type="integer" value="500" min="1" label="Height of the output image" />
-        <param name="has_header" type="boolean" checked="true" truevalue="--has_header True" falsevalue="" optional="true" label="Tabular list of shapes has header" help="Only used if the input is a tabular file (ignored for GeoJSON). Turning this off will interpret the tabular file as a list of points, where the X and Y coordinates correspond to the first and second column, respectively." />
-        <param name="swap_xy" type="boolean" checked="false" falsevalue="" truevalue="--swap_xy True" optional="true" label="Swap X and Y coordinates" help="Swap the X and Y coordinates before rasterization. The width and height of the output image is not affected." />
-        <param name="binary" type="boolean" checked="false" truevalue="--binary True" falsevalue="" optional="true" label="Produce binary image" help="Use the same label for all shapes (65535)." />
+        <param name="shapex" type="integer" value="500" min="1" label="Width of the output image"/>
+        <param name="shapey" type="integer" value="500" min="1" label="Height of the output image"/>
+        <param name="has_header" type="boolean" checked="true" truevalue="--has_header" falsevalue="" label="Tabular list of shapes has header"
+               help="Only used if the input is a tabular file (ignored for GeoJSON). Turning this off will interpret the tabular file as a list of points, where the X and Y coordinates correspond to the first and second column, respectively."/>
+        <param name="swap_xy" type="boolean" checked="false" falsevalue="" truevalue="--swap_xy" label="Swap X and Y coordinates"
+               help="Swap the X and Y coordinates before rasterization. The width and height of the output image is not affected."/>
+        <param name="binary" type="boolean" checked="false" truevalue="--binary" falsevalue="" label="Produce binary image(s)"
+               help="Use the same label for all shapes (65535)."/>
     </inputs>
     <outputs>
         <data name="output" format="tiff" />


### PR DESCRIPTION
**Updates of the implementation:**
- [x] Add `--label_property` parameter
- [x] Add `--bg_label` parameter
- [x] Add `--split` parameter

**Updates of the XML wrapper:**
- [ ] Add `label_property` parameter (type `text`, defaults to `name`)
- [ ] Add `bg_label` parameter (type `integer`, defaults to `0`)
- [ ] Add `split` parameter (type `bool`, defaults to `False`)
- [ ] Update required package versions
- [ ] Add tests for new parameters
- [ ] Automatically choose proper `dtype` for output images (prefer `uint8` over `uint16` if possible)

---

### Check-list for the contributor

**Mandatory checks:**

* [x] I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2026/03/06).
* [x] License permits unrestricted use (educational + commercial).
* [x] I agree to license these and all my past contributions to the Galaxy Image Analysis codebase under the [MIT license](https://github.com/BMCV/galaxy-image-analysis/blob/master/LICENSE.md).

**If this PR adds or updates a tool or tool collection:**

* [ ] This PR adds a new tool or tool collection.
* [x] This PR updates an existing tool or tool collection.
* [x] Tools added/updated by this PR comply with the Guidelines below (or explain why they do not).

### Guidelines for the contributor

<details>
<summary>
    This section is cited from the <a href="https://doi.org/10.37044/osf.io/w8dsz">Naming and Annotation Conventions for Tools in the Image Community in Galaxy</a>.
</summary>

<h4>Naming</h4>

Generally, the name of Galaxy tools in our community should be expressive and concise, while stating the purpose of the tool as precisely as possible. Consistency of the namings of Galaxy tools is important to ensure they can be found easily. To maintain consistency, we consider phrasing names as imperatives a good practice, such as "Analyze particles" or "Perform segmentation using watershed transformation". An acknowledged exception from this rule is the names of tool wrappers of major tool suites, where the name of a tool wrapper should be chosen identically to the module or function of the tool which is wrapped (e.g., "MaskImage" in CellProfiler).

<h4>Tool description</h4>

If a Galaxy tool is a thin tool wrapper (e.g, part of a major tool suite), then the name of the wrapped tool (and only the name of the wrapped tool, subsequent to the term "with" as in "with Bioformats") should be used as the description of the tool (further examples include "with CellProfiler", "with ImageJ2", "with ImageMagick", "with SpyBOAT", "with SuperDSM"). This ensures that the tool is found by typing the name of the wrapped tool into the "Search" field on the Galaxy interface. The tool description should be empty if a tool is either not part of a major tool suite, or the main functionality of the tool is implemented in the wrapper.

<h4>Annotations</h4>

We point out that there is a global list of precedential annotations with <a href="https://bio.tools">Bio.tools</a> identifiers (Ison et al., 2019) in Galaxy (see <a href="https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/ontologies/biotools_mappings.tsv">mappings</a>), which may outweigh the annotations made in the XML specification of a Galaxy tool (and thus the annotations of a tool reported within the web interface of Galaxy might be divergent). However, since the precedential annotations are subject to possible changes and to avoid redundant work, we do not aim to reflect those in our specifications (those which we make in the XML specifications of Galaxy tools).

</details>
