### PR TITLE
Update `ip_image_info`: Bump bftools to 8.0.0

### DIFF
--- a/tools/image_info/image_info.xml
+++ b/tools/image_info/image_info.xml
@@ -1,8 +1,8 @@
 <tool id="ip_imageinfo" name="Show image info" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="23.0">
   <description>with Bioformats</description>
   <macros>
-    <token name="@TOOL_VERSION@">5.7.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@TOOL_VERSION@">8.0.0</token>
+    <token name="@VERSION_SUFFIX@">0</token>
   </macros>
   <edam_operations>
     <edam_operation>operation_3443</edam_operation>
@@ -13,11 +13,12 @@
   <requirements>
         <requirement type="package" version="@TOOL_VERSION@">bftools</requirement>
   </requirements>
-  <command> 
-        <![CDATA[
-        showinf '$input_file' -no-upgrade -minmax -nopix > '$output'
-        ]]>
-  </command>
+  <command><![CDATA[
+
+    ln -s '$input_file' input.$input_file.ext &&
+    showinf input.$input_file.ext -no-upgrade -minmax -nopix > '$output'
+
+  ]]></command>
   <inputs>
     <param label="Input Image" name="input_file" type="data" format="scn,ndpi,tf8,vms,xml,pcx,binary,hdr,mov,psd,pbm,nrrd,tiff,pgm,ppm,txt,tf2,zip,top,gif,wav,bmp,png,gz,cif,fli,btf,jpg,avi,html,sif,tif,csv,ome.tiff,par,fits,jp2,eps,nhdr,svs,mrc"/>
   </inputs>

--- a/tools/image_info/image_info.xml
+++ b/tools/image_info/image_info.xml
@@ -20,7 +20,7 @@
 
   ]]></command>
   <inputs>
-    <param label="Input Image" name="input_file" type="data" format="scn,ndpi,tf8,vms,xml,pcx,binary,hdr,mov,psd,pbm,nrrd,tiff,pgm,ppm,txt,tf2,zip,top,gif,wav,bmp,png,gz,cif,fli,btf,jpg,avi,html,sif,tif,csv,ome.tiff,par,fits,jp2,eps,nhdr,svs,mrc"/>
+    <param label="Input Image" name="input_file" type="data" format="scn,ndpi,tf8,vms,xml,pcx,binary,hdr,mov,psd,pbm,nrrd,tiff,pgm,ppm,txt,tf2,zip,top,gif,wav,bmp,png,gz,cif,fli,btf,jpg,avi,html,sif,ome.tiff,par,fits,jp2,eps,nhdr,svs,mrc"/>
   </inputs>
   <outputs>
      <data format="txt" name="output"/>


### PR DESCRIPTION
Bump bftools to 8.0.0

Analogous to #201:
- Symlink of input file
- Remove `tif` and `csv` from input formats

---

### Check-list for the contributor

**Mandatory checks:**

* [x] I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2026/03/06).
* [x] License permits unrestricted use (educational + commercial).
* [x] I agree to license these and all my past contributions to the Galaxy Image Analysis codebase under the [MIT license](https://github.com/BMCV/galaxy-image-analysis/blob/master/LICENSE.md).

**If this PR adds or updates a tool or tool collection:**

* [ ] This PR adds a new tool or tool collection.
* [x] This PR updates an existing tool or tool collection.
* [x] Tools added/updated by this PR comply with the Guidelines below (or explain why they do not).

### Guidelines for the contributor

<details>
<summary>
    This section is cited from the <a href="https://doi.org/10.37044/osf.io/w8dsz">Naming and Annotation Conventions for Tools in the Image Community in Galaxy</a>.
</summary>

<h4>Naming</h4>

Generally, the name of Galaxy tools in our community should be expressive and concise, while stating the purpose of the tool as precisely as possible. Consistency of the namings of Galaxy tools is important to ensure they can be found easily. To maintain consistency, we consider phrasing names as imperatives a good practice, such as "Analyze particles" or "Perform segmentation using watershed transformation". An acknowledged exception from this rule is the names of tool wrappers of major tool suites, where the name of a tool wrapper should be chosen identically to the module or function of the tool which is wrapped (e.g., "MaskImage" in CellProfiler).

<h4>Tool description</h4>

If a Galaxy tool is a thin tool wrapper (e.g, part of a major tool suite), then the name of the wrapped tool (and only the name of the wrapped tool, subsequent to the term "with" as in "with Bioformats") should be used as the description of the tool (further examples include "with CellProfiler", "with ImageJ2", "with ImageMagick", "with SpyBOAT", "with SuperDSM"). This ensures that the tool is found by typing the name of the wrapped tool into the "Search" field on the Galaxy interface. The tool description should be empty if a tool is either not part of a major tool suite, or the main functionality of the tool is implemented in the wrapper.

<h4>Annotations</h4>

We point out that there is a global list of precedential annotations with <a href="https://bio.tools">Bio.tools</a> identifiers (Ison et al., 2019) in Galaxy (see <a href="https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/ontologies/biotools_mappings.tsv">mappings</a>), which may outweigh the annotations made in the XML specification of a Galaxy tool (and thus the annotations of a tool reported within the web interface of Galaxy might be divergent). However, since the precedential annotations are subject to possible changes and to avoid redundant work, we do not aim to reflect those in our specifications (those which we make in the XML specifications of Galaxy tools).

</details>
