### PR TITLE
Merge latest CI from IUC, update to 26.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,9 @@ on:
     - cron: '0 0 * * 1'
   repository_dispatch:
     types: [run-all-tool-tests-command]
-  workflow_dispatch:
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 40
 jobs:
   setup:
@@ -28,7 +27,7 @@ jobs:
     steps:
     - name: Add reaction
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
@@ -44,11 +43,11 @@ jobs:
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
       run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ steps.get-fork-branch.outputs.fork }}/galaxy refs/heads/${{ steps.get-fork-branch.outputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -57,9 +56,9 @@ jobs:
     # are not available as wheels, pip will build a wheel for them, which can be cached.
     - name: Install wheel
       run: pip install wheel
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
+        persist-credentials: false
     - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
       uses: galaxyproject/planemo-ci-action@v1
       id: discover
@@ -85,14 +84,14 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v5
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -106,7 +105,7 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: --biocontainers --skip version_bumped
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: 'Tool linting output'
@@ -133,22 +132,20 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    # checkout the repository
-    # and use it as the current working directory
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v5
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v2
+      uses: SimenB/github-actions-cpu-cores@v3
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
@@ -165,7 +162,7 @@ jobs:
         galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
         # Limit each test to 15 minutes
         test_timeout: 900
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: 'Tool test output ${{ matrix.chunk }}'
         path: upload
@@ -184,14 +181,14 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         path: artifacts
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -203,7 +200,7 @@ jobs:
         mode: combine
         html-report: true
         markdown-report: true
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: 'All tool test results'
         path: upload
@@ -215,7 +212,7 @@ jobs:
 
     - name: Create comment
       if: ${{ github.event.client_payload.slash_command.command == 'run-all-tool-tests' }}
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         token: ${{ secrets.PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,7 @@ on:
     paths-ignore:
       - 'deprecated/**'
       - 'docs/**'
+      - '.github/**'
       - '*'
   push:
     branches:
@@ -12,10 +13,11 @@ on:
     paths-ignore:
       - 'deprecated/**'
       - 'docs/**'
+      - '.github/**'
       - '*'
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_26.0
+  GALAXY_BRANCH: release_26.1
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:
@@ -57,17 +59,17 @@ jobs:
     - name: Determine latest commit in the Galaxy repo
       id: get-galaxy-sha
       run: echo "galaxy-head-sha=$(git ls-remote https://github.com/${{ env.GALAXY_FORK }}/galaxy refs/heads/${{ env.GALAXY_BRANCH }} | cut -f1)" >> $GITHUB_OUTPUT
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ steps.get-galaxy-sha.outputs.galaxy-head-sha }}
     - name: Cache .planemo
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-planemo
       with:
         path: ~/.planemo
@@ -78,9 +80,10 @@ jobs:
       run: pip install wheel
     - name: Install flake8
       run: pip install flake8 flake8-import-order
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Fake a Planemo run to update cache and determine commit range, repositories, and chunks
       uses: galaxyproject/planemo-ci-action@v1
       id: discover
@@ -100,26 +103,10 @@ jobs:
       run: |
         echo 'Using ${{ steps.discover.outputs.chunk-count }} chunks (${{ steps.discover.outputs.chunk-list }})'
 
-  # Check labels of the PR for potential switches (only for pull_request events)
-  commit_switches:
-    name: Check labels
-    runs-on: ubuntu-latest
-    outputs:
-      skip_version_check: ${{ steps.checks.outputs.skip_version_check }}
-    steps:
-    - name: Check for "skip-version-check" label
-      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'skip-version-check') }}
-      run: |
-        echo "SKIP_VERSION_CHECK=true" >> $GITHUB_ENV
-    - name: Set job outputs
-      id: checks
-      run: |
-          echo "skip_version_check=${SKIP_VERSION_CHECK}" >> $GITHUB_OUTPUT
-
   # Planemo lint the changed repositories
   lint:
     name: Lint tool-list
-    needs: [setup, commit_switches]
+    needs: setup
     if: ${{ needs.setup.outputs.repository-list != '' || needs.setup.outputs.tool-list != '' }}
     runs-on: ubuntu-latest
     strategy:
@@ -127,26 +114,50 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v5
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
-    - name: Set skip version check for push event (i.e. merge to main)
-      if: ${{ github.event_name != 'pull_request' || needs.commit_switches.outputs.skip_version_check }}
-      run:
-        echo "EXTRA_SKIP=--skip version_bumped" >> "$GITHUB_ENV"
-    - name: Set no skip for pull_request events
-      if: ${{ github.event_name == 'pull_request' && !needs.commit_switches.outputs.skip_version_check }}
-      run:
-        echo "EXTRA_SKIP=" >> "$GITHUB_ENV"
+    - name: Find Pull Request
+      id: find-pr
+      uses: sharesight/find-github-pull-request@v1.3.0
+      with:
+        allowClosed: true
+        failIfNotFound: true
+    - name: Get labels of the PR
+      uses: snnaplab/get-labels-action@v1
+      with:
+        number: ${{ steps.find-pr.outputs.number }}
+    - name: Print PR and label info
+      run: |
+        echo number: ${{ steps.find-pr.outputs.number }}
+        echo labels: ${{ env.LABELS }}
+    - name: Conditionally skip URL/version linter
+      run: |
+          set -x
+
+          to_skip=()
+          if echo '${{ env.LABELS }}' | jq -e --arg s "skip-url-check" 'index($s)' > /dev/null; then
+            to_skip+=("tool_urls")
+          fi
+          if echo '${{ env.LABELS }}' | jq -e --arg s "skip-version-check" 'index($s)' > /dev/null; then
+            to_skip+=("version_bumped")
+          fi
+
+          if [ ${#to_skip[@]} -gt 0 ]; then
+            RESULT=$(IFS=,; echo "${to_skip[*]}")
+            echo "EXTRA_SKIP=--skip $RESULT" >> "$GITHUB_ENV"
+          else
+            echo "EXTRA_SKIP=" >> "$GITHUB_ENV"
+          fi
     - name: Planemo lint
       uses: galaxyproject/planemo-ci-action@v1
       id: lint
@@ -156,7 +167,7 @@ jobs:
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
         additional-planemo-options: ${{ env.EXTRA_SKIP }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: 'Tool linting output'
@@ -173,14 +184,14 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v5
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -189,7 +200,7 @@ jobs:
       run: pip install flake8 flake8-import-order
     - name: Flake8
       run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file pylint_report.txt --tee
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: 'Python linting output'
@@ -205,14 +216,14 @@ jobs:
         os: [ubuntu-24.04]
         r-version: ['release']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
+        persist-credentials: false
     - uses: r-lib/actions/setup-r@v2
       with:
         r-version: ${{ matrix.r-version }}
     - name: Cache R packages
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ env.R_LIBS_USER }}
         key: r_cache_${{ matrix.os }}_${{ matrix.r-version }}
@@ -228,7 +239,7 @@ jobs:
         echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' -n 1 ./.github/styler.R --dry off
         git status
         git diff --exit-code | tee rlint_report.txt
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: 'R linting output'
@@ -240,9 +251,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.repository-list != '' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
+        persist-credentials: false
     - name: Check file sizes
       run: |
         touch file_size_report.txt
@@ -255,7 +267,7 @@ jobs:
           cat file_size_report.txt
           exit 1
         fi
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ failure() }}
       with:
         name: 'File size report'
@@ -267,10 +279,11 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && needs.setup.outputs.tool-list != '' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-    - uses: actions/setup-python@v6
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: '3.10'
     - name: Install requirements
@@ -316,26 +329,26 @@ jobs:
         ports:
           - 5432:5432
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v5
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Cache .planemo
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-planemo
       with:
         path: ~/.planemo
         key: planemo_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v2
+      uses: SimenB/github-actions-cpu-cores@v3
       id: cpu-cores
     - name: Clean dotnet folder for space
       run: rm -Rf /usr/share/dotnet
@@ -351,8 +364,8 @@ jobs:
         chunk-count: ${{ needs.setup.outputs.chunk-count }}
         galaxy-slots: ${{ steps.cpu-cores.outputs.count }}
         # Limit each test to 15 minutes
-        test_timeout: 1800
-    - uses: actions/upload-artifact@v4
+        test_timeout: 900
+    - uses: actions/upload-artifact@v7
       with:
         name: 'Tool test output ${{ matrix.chunk }}'
         path: upload
@@ -371,14 +384,14 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         path: artifacts
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -390,7 +403,7 @@ jobs:
         mode: combine
         html-report: true
         markdown-report: true
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: 'All tool test results'
         path: upload
@@ -402,7 +415,8 @@ jobs:
         mode: check
     - name: Check if all test chunks succeeded
       run: |
-        NFILES=$(ls artifacts/ | grep "Tool test output" | wc -l)
+        ls artifacts/
+        NFILES=$(find artifacts/ -name "tool_test_output.json" | wc -l)
         if [[ "${{ needs.setup.outputs.chunk-count }}" != "$NFILES" ]]; then
           exit 1
         fi
@@ -417,14 +431,14 @@ jobs:
       matrix:
         python-version: ['3.11']
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
-        fetch-depth: 1
-    - uses: actions/setup-python@v5
+        persist-credentials: false
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache .cache/pip
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache-pip
       with:
         path: ~/.cache/pip
@@ -448,22 +462,22 @@ jobs:
   deploy-report:
     name: Report deploy status
     needs: [deploy]
-    if: ${{ always() && needs.setup.outputs.repository-list != '' && needs.deploy.result != 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') && github.repository_owner == 'BMCV' }}
+    if: ${{ always() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'BMCV' }}
     runs-on: ubuntu-latest
     steps:
     # report to the PR if deployment failed
     - name: Get PR object
-      uses: 8BitJonny/gh-get-current-pr@2.2.0
+      uses: 8BitJonny/gh-get-current-pr@4.0.0
       id: getpr
       with:
         sha: ${{ github.event.after }}
     - name: Create comment
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         token: ${{ secrets.PAT }}
         issue-number: ${{ steps.getpr.outputs.number }}
         body: |
-          Attention: deployment ${{ needs.deploy.result }}!
+          Deployment status: **${{ needs.deploy.result }}**
 
           https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
Merge latest CI from IUC:
- [ci.yaml @`5657f2a31e6b020c5f892a12b7b35c58fcfc23ac`](https://github.com/galaxyproject/tools-iuc/blob/5657f2a31e6b020c5f892a12b7b35c58fcfc23ac/.github/workflows/ci.yaml)
- [pr.yaml @`5657f2a31e6b020c5f892a12b7b35c58fcfc23ac`](https://github.com/galaxyproject/tools-iuc/blob/5657f2a31e6b020c5f892a12b7b35c58fcfc23ac/.github/workflows/pr.yaml)

This includes updating to Galaxy 26.1 branch.

---

### Check-list for the contributor

**Mandatory checks:**

* [x] I have read the [CONTRIBUTING.md](https://github.com/BMCV/galaxy-image-analysis/blob/master/CONTRIBUTING.md) document (last updated: 2026/03/06).
* [x] License permits unrestricted use (educational + commercial).
* [x] I agree to license these and all my past contributions to the Galaxy Image Analysis codebase under the [MIT license](https://github.com/BMCV/galaxy-image-analysis/blob/master/LICENSE.md).

**If this PR adds or updates a tool or tool collection:**

* [ ] This PR adds a new tool or tool collection.
* [ ] This PR updates an existing tool or tool collection.
* [ ] Tools added/updated by this PR comply with the Guidelines below (or explain why they do not).

### Guidelines for the contributor

<details>
<summary>
    This section is cited from the <a href="https://doi.org/10.37044/osf.io/w8dsz">Naming and Annotation Conventions for Tools in the Image Community in Galaxy</a>.
</summary>

<h4>Naming</h4>

Generally, the name of Galaxy tools in our community should be expressive and concise, while stating the purpose of the tool as precisely as possible. Consistency of the namings of Galaxy tools is important to ensure they can be found easily. To maintain consistency, we consider phrasing names as imperatives a good practice, such as "Analyze particles" or "Perform segmentation using watershed transformation". An acknowledged exception from this rule is the names of tool wrappers of major tool suites, where the name of a tool wrapper should be chosen identically to the module or function of the tool which is wrapped (e.g., "MaskImage" in CellProfiler).

<h4>Tool description</h4>

If a Galaxy tool is a thin tool wrapper (e.g, part of a major tool suite), then the name of the wrapped tool (and only the name of the wrapped tool, subsequent to the term "with" as in "with Bioformats") should be used as the description of the tool (further examples include "with CellProfiler", "with ImageJ2", "with ImageMagick", "with SpyBOAT", "with SuperDSM"). This ensures that the tool is found by typing the name of the wrapped tool into the "Search" field on the Galaxy interface. The tool description should be empty if a tool is either not part of a major tool suite, or the main functionality of the tool is implemented in the wrapper.

<h4>Annotations</h4>

We point out that there is a global list of precedential annotations with <a href="https://bio.tools">Bio.tools</a> identifiers (Ison et al., 2019) in Galaxy (see <a href="https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/tool_util/ontologies/biotools_mappings.tsv">mappings</a>), which may outweigh the annotations made in the XML specification of a Galaxy tool (and thus the annotations of a tool reported within the web interface of Galaxy might be divergent). However, since the precedential annotations are subject to possible changes and to avoid redundant work, we do not aim to reflect those in our specifications (those which we make in the XML specifications of Galaxy tools).

</details>
